### PR TITLE
⚡ Optimize CRL lookup and fix serial number format mismatch

### DIFF
--- a/Leaked Keyboxs/💀/tarball/Check Keybox/keybox_check.py
+++ b/Leaked Keyboxs/💀/tarball/Check Keybox/keybox_check.py
@@ -59,6 +59,15 @@ if crl is None:
     logging.critical("Unable to proceed without a valid CRL.")
     sys.exit(1)
 
+# Convert CRL entries to a set of hex serial numbers for O(1) lookup
+revoked_serial_numbers = set()
+if crl and "entries" in crl:
+    for sn in crl["entries"]:
+        try:
+            revoked_serial_numbers.add(f'{int(sn):x}')
+        except ValueError:
+            revoked_serial_numbers.add(sn.lower())
+
 def parse_cert(cert: str) -> Optional[str]:
     """Parse a certificate and return its serial number."""
     try:
@@ -120,7 +129,7 @@ def main():
             continue
 
         # Check revocation status
-        if any(sn in crl["entries"] for sn in (ec_cert_sn, rsa_cert_sn)):
+        if any(sn in revoked_serial_numbers for sn in (ec_cert_sn, rsa_cert_sn)):
             logging.info(f"\n{Fore.RED}{BOLD}[REVOKED] {filename}")
             logging.info(f"  EC Cert Serial Number: {ec_cert_sn}")
             logging.info(f"  RSA Cert Serial Number: {rsa_cert_sn}")


### PR DESCRIPTION
*   **What:** Converted the CRL entries from the JSON response into a Python `set` of hexadecimal strings.
*   **Why:**
    *   **Performance:** Enables O(1) membership checks for revocation status.
    *   **Correctness:** The original code compared hexadecimal serial numbers (from certificates) against decimal keys (from CRL), causing the check to always fail (finding no revocations). The new implementation converts CRL keys to hexadecimal to match the certificate format, ensuring revocations are correctly detected.
*   **Measured Improvement:**
    *   Baseline: The check was functionally broken (always False).
    *   Improvement: The check is now correct and uses O(1) lookup. Verified with a test certificate (`test_revoked.xml` with serial `6681152659205225093` / `5cb838f1fe157a85`) which is now correctly identified as **[REVOKED]**.

---
*PR created automatically by Jules for task [14182883149054837585](https://jules.google.com/task/14182883149054837585) started by @tryigit*