### PR TITLE
⚡ Bolt: Batch `su` calls in SystemAppAdd.sh

### DIFF
--- a/PIFB/SystemAppAdd.sh
+++ b/PIFB/SystemAppAdd.sh
@@ -14,17 +14,18 @@ if [ -d "/data/adb/modules/zygisk_lsposed" ] || [ -d "/data/adb/modules/zygisk_s
 fi
 
 rm -rf /data/adb/tricky_store/AllAppsTarget.sh
-su -c "magisk --denylist add com.google.android.gms com.google.android.gms.unstable"
-su -c "magisk --denylist add com.google.android.gsf com.google.process.gservices"
-su -c "magisk --denylist add com.google.android.gsf com.google.process.gapps"
+# Optimization: Batch multiple root commands into a single su session to reduce overhead
+{
+    echo "magisk --denylist add com.google.android.gms com.google.android.gms.unstable"
+    echo "magisk --denylist add com.google.android.gsf com.google.process.gservices"
+    echo "magisk --denylist add com.google.android.gsf com.google.process.gapps"
 
-# PIFS
-if [ -d "/data/adb/tricky_store" ] || [ -d "/data/adb/modules_update/tricky_store" ]; then
-    su -c rm -f /data/adb/tricky_store/AllAppTarget.sh
-    
-    su -c > /data/adb/tricky_store/target.txt
-    su -c pm list packages | awk -F: '{print $2}' > /data/adb/tricky_store/target.txt
-fi 
+    # PIFS
+    echo "if [ -d '/data/adb/tricky_store' ] || [ -d '/data/adb/modules_update/tricky_store' ]; then"
+    echo "    rm -f /data/adb/tricky_store/AllAppTarget.sh"
+    echo "    pm list packages | awk -F: '{print \$2}' > /data/adb/tricky_store/target.txt"
+    echo "fi"
+} | su -c sh
 
 # PIFB/PIFS
 


### PR DESCRIPTION
💡 What: Consolidates multiple `magisk --denylist add` commands and file operations into a single `su` session.
🎯 Why: Spawning a new shell and elevating privileges via `su` is expensive on Android. Reducing the number of `su` calls improves script execution speed.
📊 Impact: Reduces `su` invocations from 4-5 to 1 in the affected block.
🔬 Measurement: Verify script execution time and ensure all denylist entries are correctly added. Check `/data/adb/tricky_store/target.txt` generation.

---
*PR created automatically by Jules for task [14187420775630781224](https://jules.google.com/task/14187420775630781224) started by @tryigit*